### PR TITLE
fix KeyNotFoundException bug and repeated references bug

### DIFF
--- a/ReferenceFinder/ReferenceFinderData.cs
+++ b/ReferenceFinder/ReferenceFinderData.cs
@@ -57,7 +57,10 @@ public class ReferenceFinderData
         {
             foreach(var assetGuid in asset.Value.dependencies)
             {
-                assetDict[assetGuid].references.Add(asset.Key);
+                if(assetDict.ContainsKey(assetGuid) && !assetDict[assetGuid].references.Contains(asset.Key))
+                {
+                    assetDict[assetGuid].references.Add(asset.Key);
+                }
             }
         }
     }


### PR DESCRIPTION
fix KeyNotFoundException bug and repeated references bug in unity2018.4.29 and unity2019.4.21f1c1

环境：unity2018.4.29 、unity2019.4.21f1c1
修复了KeyNotFoundException  bug
修复了点击Refresh Data后资源的references会重复出现两次的bug

