### PR TITLE
fix: 修复命名空间导致的报错

### DIFF
--- a/ReferenceFinder/ReferenceFinderWindow.cs
+++ b/ReferenceFinder/ReferenceFinderWindow.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEditor.IMGUI.Controls;
 using System.Runtime.InteropServices;
 using System;
-using static UnityEngine.Rendering.DebugUI;
+// using static UnityEngine.Rendering.DebugUI;
 using static UnityEditor.Progress;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
ReferenceFinderWindows.cs中的命名空间在部分情况下会报错导致Unity编译失败.
修复方式:注释掉可能出现问题的命名空间